### PR TITLE
Update attachments FLIP

### DIFF
--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -260,6 +260,8 @@ pub resource R {
 }
 ```
 
+Attempting to attach new attachments to `R` or remove attachments from `R` while iterating over it is a runtime error. 
+
 ### Drawbacks
 
 Adding a new language feature has the downside of complexity: users have to learn yet another 

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -191,7 +191,10 @@ first to guarantee that the value does not have that attachment before they atte
 The `attach` expression creates a new value, rather than modifying the old one; thus if the base is a struct, the result of the expression will have the attachment,
 while the original value will not. In the case of a resource, the old resource will be moved into the new one, which will have the attachment present. It is also worth
 noting that while `super` does point to the base during the attachment's constructor, that base does not yet have the attachment present on it during the execution
-of that constructor; that only occurs after the attachment expresion successfully executes. 
+of that constructor; that only occurs after the attachment expresion successfully executes. To see why, consider what would happen if a user accessed that attachment 
+through super; if in `A`'s initializer they wrote `super[A]!.foo?`. This could potentially allow `A`'s `foo` field to be accessed before it has been initialized, and
+would require analysis of statement ordering within the initializer itself to determine when it was safe to access which fields of `A` through super. Rather than add
+this additional complexity, we simply do not attach `A` to the base until after the initializer has finished executing. 
 
 ### Removing Attachments from a Type
 

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -188,6 +188,11 @@ If a users attempts to `attach` an attachment to a value that already possesses 
 reason, if a user has reason to believe that an attachment of the type they wish to add already exists on a value, they should use the `remove` statement 
 first to guarantee that the value does not have that attachment before they attempt to attach it again.
 
+The `attach` expression creates a new value, rather than modifying the old one; thus if the base is a struct, the result of the expression will have the attachment,
+while the original value will not. In the case of a resource, the old resource will be moved into the new one, which will have the attachment present. It is also worth
+noting that while `super` does point to the base during the attachment's constructor, that base does not yet have the attachment present on it during the execution
+of that constructor; that only occurs after the attachment expresion successfully executes. 
+
 ### Removing Attachments from a Type
 
 Attachments can be removed with a new statement: `remove t from e`. Here, `t` refers to an attachment type name, rather than a value, 

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -55,9 +55,9 @@ As with other type declarations, attachments may only have a `pub` access modifi
 but until such a proposal exists and is accepted, the access modifier on an attachment declaration must be `pub`. 
 
 Within the attachment declaration, fields and functions can be defined the same way they would be in a struct or resource declaration, with an access modifier and 
-a declaration kind. The fields of the base type for which the attachment are accessible to the attachment using the `super` value, which is an implicit field 
-of the attachment that is a reference to the base type. So, for an attachment declared `pub attachment Foo for Bar`, the `super` field of `Foo` would have type `&Bar`.
-The fields and functions defined on the attachment itself would be accessible using the `self` value as normal. Note, however, that attachments only have access to the same fields and functions on the `super` field as other code declared in the same place would have; i.e. an attachment defined in the same contract as its original type would have access to `pub` and `access(contract)` fields and functions on `super`, but not `priv` fields or functions, while an attachment defined in a different contract and account to its original type would only be able to reference `pub` fields and functions on the `super` field. 
+a declaration kind. The fields of the base type for which the attachment are accessible to the attachment using the `base` value, which is an implicit field 
+of the attachment that is a reference to the base type. So, for an attachment declared `pub attachment Foo for Bar`, the `base` field of `Foo` would have type `&Bar`.
+The fields and functions defined on the attachment itself would be accessible using the `self` value as normal. Note, however, that attachments only have access to the same fields and functions on the `base` field as other code declared in the same place would have; i.e. an attachment defined in the same contract as its original type would have access to `pub` and `access(contract)` fields and functions on `base`, but not `priv` fields or functions, while an attachment defined in a different contract and account to its original type would only be able to reference `pub` fields and functions on the `base` field. 
 
 So, for example, this would be a valid declaration of an attachment:
 
@@ -76,11 +76,11 @@ pub attachment A for R {
     pub let derivedX: Int 
 
     init (_ scalar: Int) {
-        self.derivedX = super.x * scalar
+        self.derivedX = base.x * scalar
     }
 
     pub fun foo() {
-        super.foo()
+        base.foo()
     }
 }
 
@@ -88,7 +88,7 @@ pub attachment A for R {
 
 Any fields that are declared in an attachment must be initialized, just as any fields declared in a composite must be. An attachment
 that declares fields must declare an initializer, which is run when the attachment is created. The `init` function on an attachment is run after
-the attachment is attached to the base type, so `super` is accessible in the initializer.
+the attachment is attached to the base type, so `base` is accessible in the initializer.
 
 The same checks on normal initializers apply to attachment initializers; namely that all the fields declared in the attachment must be initialized with a value in the
 attachment's initializer. So, the following would be a legal attachment:
@@ -120,7 +120,7 @@ pub attachment E for R {
 
 Any resource fields (which are only legal in resource attachments) must also be explicitly handled in a `destroy` function, which is run when
 the attachment is destroyed/removed from its base type. Like `init`, because `destroy` will be before the attachment is actually removed from the base
-type, `super` will be populated and accessible in the function body. 
+type, `base` will be populated and accessible in the function body. 
 
 If a resource with attachments on it is `destroy`ed, the `destroy` functions of all its attachments are all run in an unspecified order; `destroy` should not
 rely on the presence of other attachments on the base type in its implementation. The only guarantee about the order in which attachments are destroyed in this case
@@ -129,7 +129,7 @@ is that the base type will be the last thing destroyed.
 An attachment declared with `pub attachment A for C { ... }` will have a nominal type `A`.
 
 If an attachment `A` is declared to conform to an interface `I`, `A` will be a subtype of `{I}`, and the checker will enforce that `A` implements all the functions 
-and fields of `I`. Note that an attachment must implement all the functions and fields of `I` itself; it may reference its base type with `super` but it cannot inherit 
+and fields of `I`. Note that an attachment must implement all the functions and fields of `I` itself; it may reference its base type with `base` but it cannot inherit 
 from that type. 
 
 Important note: because attachments are not first class values in Cadence, their types cannot appear outside of a reference type. So, for example, given an 
@@ -190,10 +190,10 @@ first to guarantee that the value does not have that attachment before they atte
 
 The `attach` expression creates a new value, rather than modifying the old one; thus if the base is a struct, the result of the expression will have the attachment,
 while the original value will not. In the case of a resource, the old resource will be moved into the new one, which will have the attachment present. It is also worth
-noting that while `super` does point to the base during the attachment's constructor, that base does not yet have the attachment present on it during the execution
+noting that while `base` does point to the base during the attachment's constructor, that base does not yet have the attachment present on it during the execution
 of that constructor; that only occurs after the attachment expresion successfully executes. To see why, consider what would happen if a user accessed that attachment 
-through super; if in `A`'s initializer they wrote `super[A]!.foo?`. This could potentially allow `A`'s `foo` field to be accessed before it has been initialized, and
-would require analysis of statement ordering within the initializer itself to determine when it was safe to access which fields of `A` through super. Rather than add
+through `base`; if in `A`'s initializer they wrote `base[A]!.foo?`. This could potentially allow `A`'s `foo` field to be accessed before it has been initialized, and
+would require analysis of statement ordering within the initializer itself to determine when it was safe to access which fields of `A` through `base`. Rather than add
 this additional complexity, we simply do not attach `A` to the base until after the initializer has finished executing. 
 
 ### Removing Attachments from a Type
@@ -232,7 +232,7 @@ On a structure, it will have
 fun forEachAttachment(_ f: ((&AnyStructAttachment): Void)): Void 
 ```
 
-`AnyResourceAttachment`/`AnyStructAttachment` are new types that expresses the supertypes of all struct/resource attachments.
+`AnyResourceAttachment`/`AnyStructAttachment` are new types that expresses the basetypes of all struct/resource attachments.
 They contains two functions (that are implicitly present on all attachments): `getField` and `getFunction`, 
 with the following signatures:
 

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -203,9 +203,7 @@ If a resource containing attachments is `destroy`ed, all its attachments will be
 
 ### Accessing Attachments
 
-Once an attachment has been added to a composite value, it can be accessed using indexing syntax: `v[T]`, where `v` is a resource or struct composite value, 
-and `T` is the name of an attachment type. This indexing syntax returns an optional reference to the attachment of type `T`: `&T?`; if no such attachment exists on `v`, 
-the expression will return `nil`. So, given a composite `r` with an attachment of type `A`, accessing `A`'s `foo` function would be done like so:
+Once an attachment has been added to a composite value, it can be accessed using indexing syntax: `v[T]`, where `v` is a resource or struct composite value, or a reference to a struct or resource composite value, and `T` is the name of an attachment type. This indexing syntax returns an optional non-auth reference to the attachment of type `T`: `&T?`; if no such attachment exists on `v`, the expression will return `nil`. So, given a composite `r` with an attachment of type `A`, accessing `A`'s `foo` function would be done like so:
 
 ```cadence
 r[A]!.foo()

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -217,7 +217,7 @@ Once an attachment has been added to a composite value, it can be accessed using
 r[A]!.foo()
 ```
 
-This syntax is only valid if `A` is a valid attachment type for `v`; i.e. if `A`'s declared base type is a subtype of the type of `v`. What this means is that the owner
+This syntax is only valid if `A` is a valid attachment type for `v`; i.e. if `A`'s declared base type is a supertype of the type of `v`. What this means is that the owner
 of a resource can restrict which attachments can be accessed on references to their resource using restricted types, much like they would do with any other field or function. E.g.
 
 ```

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -217,6 +217,18 @@ Once an attachment has been added to a composite value, it can be accessed using
 r[A]!.foo()
 ```
 
+This syntax is only valid if `A` is a valid attachment type for `v`; i.e. if `A`'s declared base type is a subtype of the type of `v`. What this means is that the owner
+of a resource can restrict which attachments can be accessed on references to their resource using restricted types, much like they would do with any other field or function. E.g.
+
+```
+struct R: I {}
+struct interface I {}
+attachment A for R {}
+fun foo(r: &{I}) {
+    r[A] // fails to type check, because `{I}` is not a subtype of `R`
+}
+```
+
 ### Iterating over Attachments
 
 All composite types will contain a new function `forEachAttachment` that iterates over all the attachments present on that composite. On a resource, this function 


### PR DESCRIPTION
* Explicitly mention that attachment access can occur on references, and returns a non-auth reference.

* Mention that attempting to modify a composite's attachments while iterating over it is an error. 

* Explain that `base` is not populated with a new attachment `A` until `A`'s constructor finishes executing during `attach`

* Rename `super` to `base`.  