### PR TITLE
Move reflection/iteration to separate section and propose accepting FLIP

### DIFF
--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -264,13 +264,14 @@ of that function will be returne from `invokeFunction`. Otherwise, `invokeFuncti
 `getField` takes the `name` and a type of a field on an attachment, returning a reference to that field if it is present with that type, but `nil` if the member
 does not exist or is a function. 
 
-Note that `getField` and `invokeFunction` cannot be used to circumvent access control. I.e. a field declared `priv` cannot be accessed outside of the body of that
-`attachment`, and a function declared with `access(contract)` cannot be invoked outside of the contract in which the attachment was defined. For similar reasons, 
-`forEachAttachment` will only iterate over those attachments on the receiver that could be accessed on that receiver using the normal access syntax; that is, 
-if a receiver has a static type that is larger than its runtime time, any attachments present on it declared for a type smaller than its static type will be 
-skipped during the call. For example, if an attachment `A` is created for `Vault` and attached to a `Vault` object, if a `&{Receiver}` reference is exposed
-to that `Vault`, when iterating over that restricted reference's attachments, `A` will be skipped, as it should not be possible to access `Vault` attachments
-with only a `Receiver` value.  
+Note that in order to prevent `getField` and `invokeFunction` from being used to circumvent access control, these functions can only be used to access 
+attachment members that were declared to have `pub` access. 
+
+For similar reasons, `forEachAttachment` will only iterate over those attachments on the receiver that could be accessed on that receiver using the normal 
+access syntax; that is, if a receiver has a static type that is larger than its runtime time, any attachments present on it declared for a type smaller than 
+its static type will be skipped during the call. For example, if an attachment `A` is created for `Vault` and attached to a `Vault` object, if a `&{Receiver}` 
+reference is exposed to that `Vault`, when iterating over that restricted reference's attachments, `A` will be skipped, as it should not be possible to access 
+`Vault` attachments with only a `Receiver` value.  
 
 So, for example, if the creator of a resource would like to have a function that returns the a descriptive string describing that resource and all its attachments, 
 they may implement it this way:

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -265,7 +265,12 @@ of that function will be returne from `invokeFunction`. Otherwise, `invokeFuncti
 does not exist or is a function. 
 
 Note that `getField` and `invokeFunction` cannot be used to circumvent access control. I.e. a field declared `priv` cannot be accessed outside of the body of that
-`attachment`, and a function declared with `access(contract)` cannot be invoked outside of the contract in which the attachment was defined. 
+`attachment`, and a function declared with `access(contract)` cannot be invoked outside of the contract in which the attachment was defined. For similar reasons, 
+`forEachAttachment` will only iterate over those attachments on the receiver that could be accessed on that receiver using the normal access syntax; that is, 
+if a receiver has a static type that is larger than its runtime time, any attachments present on it declared for a type smaller than its static type will be 
+skipped during the call. For example, if an attachment `A` is created for `Vault` and attached to a `Vault` object, if a `&{Receiver}` reference is exposed
+to that `Vault`, when iterating over that restricted reference's attachments, `A` will be skipped, as it should not be possible to access `Vault` attachments
+with only a `Receiver` value.  
 
 So, for example, if the creator of a resource would like to have a function that returns the a descriptive string describing that resource and all its attachments, 
 they may implement it this way:

--- a/cadence/2022-09-21-attachments.md
+++ b/cadence/2022-09-21-attachments.md
@@ -1,11 +1,10 @@
 # Attachments
 
-| Status        | (Proposed)                                           |
+| Status        | (Approved)                                           |
 :-------------- |:---------------------------------------------------- |
-| **FLIP #**    | [NNN](Link to FLIP)                                  |
 | **Author(s)** | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
 | **Sponsor**   | Daniel Sainati (daniel.sainati@dapperlabs.com)       |
-| **Updated**   | 2022-10-26                                           |
+| **Updated**   | 2022-11-23                                           |
 
 ## Objective
 
@@ -229,6 +228,23 @@ fun foo(r: &{I}) {
 }
 ```
 
+### Drawbacks
+
+Adding a new language feature has the downside of complexity: users have to learn yet another 
+concept, and it also complicates the language implementation.
+
+However, this language feature can be disclosed progressively, users can discover and use it when needed, 
+it is not necessary to be understood for core use-cases of the language, i.e. the target audience is mostly “power-users”.
+
+### Compatibility
+
+This is backwards compatible, as it does not invalidate any existing Cadence code. 
+
+## Related Issues
+
+There is a plan to add support for iterating over and reflecting on attachments in a future FLIP. 
+A summary of the future proposed changes (which used to be part of this FLIP) are included below:
+
 ### Iterating over Attachments
 
 All composite types will contain a new function `forEachAttachment` that iterates over all the attachments present on that composite. On a resource, this function 
@@ -293,25 +309,6 @@ pub resource R {
 ```
 
 Attempting to attach new attachments to `R` or remove attachments from `R` while iterating over it is a runtime error. 
-
-### Drawbacks
-
-Adding a new language feature has the downside of complexity: users have to learn yet another 
-concept, and it also complicates the language implementation.
-
-However, this language feature can be disclosed progressively, users can discover and use it when needed, 
-it is not necessary to be understood for core use-cases of the language, i.e. the target audience is mostly “power-users”.
-
-### Tutorials and Examples
-
-* TODO: fill in later once the details of the design are decided
-
-### Compatibility
-
-This is backwards compatible, as it does not invalidate any existing Cadence code. 
-
-## Related Issues
-
 ## Alternatives
 
 In a previous [FLIP](https://github.com/onflow/flow/pull/1101), a solution to the extensibility


### PR DESCRIPTION
This changes the status of the FLIP to accepted, and moves the reflection and iteration API to a future "related changes" section, to be handled in another FLIP. 

It also makes some adjustments to the details of the proposal for attachment reflection and iteration, with a mind towards improving security:

* `getFunction` is changed to `invokeFunction` in order not to create bound function values on resources
* Note is added about the reflection functions not being able to access fields/functions that should not be accessible due to their access control sigils, so we restrict these to `pub` functions
* `forEachAttachment` should skip over attachments that are not statically accessible to the receiver type. This is to prevent someone with a `Receiver` reference from accessing `Vault` attachments, and thereby getting a potential reference to the `Vault` through the `base`. 