### PR TITLE
Mark Even Streaming FLIP as accpted

### DIFF
--- a/protocol/20230309-accessnode-event-streaming-api.md
+++ b/protocol/20230309-accessnode-event-streaming-api.md
@@ -1,9 +1,9 @@
 ---
-status: proposed
+status: accepted
 flip: 73
 authors: Peter Argue (peter.argue@dapperlabs.com)
 sponsor: Jerome Pimmel (jerome.pimmel@dapperlabs.com)
-updated: 2023-03-09
+updated: 2023-06-06
 ---
 
 # FLIP 73: Event Streaming API (alpha version)


### PR DESCRIPTION
We forgot to mark the FLIP as accepted when merging. updated the doc to reflect its status.