### PR TITLE
Reject GOV-3

### DIFF
--- a/governance/20221005-dynamic-inclusion-fee.md
+++ b/governance/20221005-dynamic-inclusion-fee.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: rejected
 flip: GOV-3
 forum: https://forum.onflow.org/t/flip-dynamic-inclusion-fees/3700
 authors: Tony Zhang (tony.zhang@dapperlabs.com)


### PR DESCRIPTION
Due to inactivity. We can un-reject it when we get back to it.