### PR TITLE
New workflow to set issue assingnee automatically 

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,0 +1,14 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2

--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,10 +1,11 @@
-name: Auto Author Assign
-
 on:
+  issues:
+    types: [ opened, reopened ]
   pull_request_target:
     types: [ opened, reopened ]
 
 permissions:
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Adding workflow to automatically set the author of an issue as the assignee of the issue.