### PR TITLE
updating status of Message Handling Flip-343

### DIFF
--- a/protocol/20210201-consuming-messages-from-network-layer.md
+++ b/protocol/20210201-consuming-messages-from-network-layer.md
@@ -1,5 +1,5 @@
 ---
-status: Implemented
+status: Released (most of the important Engines have been updated)
 flip: 343
 authors: Alex Hentschel (alex.hentschel@dapperlabs.com)
 sponsor: Alex Hentschel (alex.hentschel@dapperlabs.com)


### PR DESCRIPTION
Most of the important Engines have been updated. Hence, I would recommend changing the status of this flip to `Released` 